### PR TITLE
Python Version Update to 3.8.X and Section Additions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ If the page notebooks won't load on GitHub view them here:
  - `Python Tips <https://nbviewer.jupyter.org/github/gpetepg/python_tips/blob/master/python_tips.ipynb/>`_.
  - `Built-In-Libraries <https://nbviewer.jupyter.org/github/gpetepg/python_tips/blob/master/built_in_library_tips.ipynb/>`_.
 
-Note that these were written in Python 3 (3.6)
+Note that these were written in Python 3 (3.8.X).
 
 These files are .ipynb. It is a notebook document used by Jupyter Notebook, an interactive computational environment designed to help scientists work with the Python language (as well as many others e.g. R, Julia, Ruby, JavaScript).
 

--- a/built_in_functions_and_libraries.ipynb
+++ b/built_in_functions_and_libraries.ipynb
@@ -238,7 +238,7 @@
     {
      "data": {
       "text/plain": [
-       "<zip at 0x7ff03ccbd6c0>"
+       "<zip at 0x7fa3184bf680>"
       ]
      },
      "execution_count": 9,
@@ -459,7 +459,8 @@
      "text": [
       "These are very useful you can use f-strings on this too.\n",
       "These will keep the formatting within the string\n",
-      "\n"
+      "\n",
+      "name='tyler'\n"
      ]
     }
    ],
@@ -470,7 +471,12 @@
     "\n",
     "print(f\"\"\"These are very useful you can use {string} on this too.\n",
     "These will keep the formatting within the string\n",
-    "\"\"\")"
+    "\"\"\")\n",
+    "\n",
+    "#You can also print the value and variable name together like this:\n",
+    "\n",
+    "name = \"tyler\"\n",
+    "print(f\"{name=}\")"
    ]
   },
   {
@@ -811,7 +817,7 @@
     {
      "data": {
       "text/plain": [
-       "'2022-08-23 00:53:52.890433'"
+       "'2022-08-23 15:19:10.314056'"
       ]
      },
      "execution_count": 33,
@@ -835,7 +841,7 @@
     {
      "data": {
       "text/plain": [
-       "'datetime.datetime(2022, 8, 23, 0, 53, 52, 922075)'"
+       "'datetime.datetime(2022, 8, 23, 15, 19, 10, 329810)'"
       ]
      },
      "execution_count": 34,
@@ -1103,7 +1109,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['a', 'b', 'c', 'f', 'e', 'd', 'g', 'h', 'i', 'j', 'k', 'l']\n"
+      "['a', 'b', 'c', 'e', 'd', 'f', 'g', 'h', 'i', 'j', 'k', 'l']\n"
      ]
     }
    ],
@@ -1152,7 +1158,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['a', 'b', 'c', 'f', 'e', 'd', 'g', 'h', 'i', 'j', 'k', 'l']\n"
+      "['a', 'b', 'c', 'e', 'd', 'f', 'g', 'h', 'i', 'j', 'k', 'l']\n"
      ]
     }
    ],
@@ -1669,7 +1675,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(<itertools._tee object at 0x7ff03cce4b40>, <itertools._tee object at 0x7ff03cba0d40>, <itertools._tee object at 0x7ff03cba09c0>)\n"
+      "(<itertools._tee object at 0x7fa3183be840>, <itertools._tee object at 0x7fa3183bed40>, <itertools._tee object at 0x7fa3183be540>)\n"
      ]
     }
    ],
@@ -3190,7 +3196,7 @@
     {
      "data": {
       "text/plain": [
-       "datetime.datetime(2022, 8, 23, 0, 53, 54, 59962)"
+       "datetime.datetime(2022, 8, 23, 15, 19, 11, 519484)"
       ]
      },
      "execution_count": 116,

--- a/built_in_functions_and_libraries.ipynb
+++ b/built_in_functions_and_libraries.ipynb
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,9 +79,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[12, 14, 16, 18, 20, 22, 24, 26, 28, 30]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Using a standard function.\n",
     "\n",
@@ -90,9 +101,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[12, 14, 16, 18, 20, 22, 24, 26, 28, 30]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Using a lambda function.\n",
     "\n",
@@ -111,18 +133,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "list_1"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[6, 7, 8, 9, 10]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Filter for elements greater than 5\n",
     "\n",
@@ -141,9 +185,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Tim': 'dog', 'Steve': 'cat', 'Matt': 'sheep'}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Very useful when making a dictionary\n",
     "\n",
@@ -155,9 +210,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('Tim', 'dog'), ('Steve', 'cat'), ('Matt', 'sheep')]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Will make a tuple by default\n",
     "\n",
@@ -166,9 +232,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<zip at 0x7fe158601500>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# It will return as an object so you need a list() or dict() call to return anything\n",
     "zip(animal_names, animals)"
@@ -176,9 +253,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'a': 1, 'b': 2, 'c': 3, 'd': 4}\n"
+     ]
+    }
+   ],
    "source": [
     "# Quick way to zip dictionaries\n",
     "\n",
@@ -199,11 +284,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n",
+      "2\n",
+      "3\n",
+      "4\n",
+      "5\n",
+      "6\n",
+      "7\n",
+      "8\n",
+      "9\n",
+      "10\n"
+     ]
+    }
+   ],
    "source": [
     "# Standard for loop print:\n",
     "for i in list_1:\n",
@@ -212,9 +314,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 2 3 4 5 6 7 8 9 10 "
+     ]
+    }
+   ],
    "source": [
     "# For loop printing on the same line\n",
     "\n",
@@ -224,9 +334,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 2 3 4 5 6 7 8 9 10\n"
+     ]
+    }
+   ],
    "source": [
     "# Quickest way of unpacking of a list, although it prints on the same line.\n",
     "print(*list_1)"
@@ -234,9 +352,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n",
+      "2\n",
+      "3\n",
+      "4\n",
+      "5\n",
+      "6\n",
+      "7\n",
+      "8\n",
+      "9\n",
+      "10\n"
+     ]
+    }
+   ],
    "source": [
     "# Quicker way than a for loop with a new line.\n",
     "print(*list_1, sep=\"\\n\") "
@@ -255,20 +390,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "I'm using an apostrophe\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"I'm using an apostrophe\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Use triple quotes for these\n",
+      "Or these\n"
+     ]
+    }
+   ],
    "source": [
     "print('''Use triple quotes for these''')\n",
     "\n",
@@ -277,9 +429,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "These are very useful you can use .format on this too.\n",
+      "These will keep the formatting within the string\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "print('''These are very useful you can use {} on this too.\n",
     "These will keep the formatting within the string\n",
@@ -288,9 +450,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "These are very useful you can use f-strings on this too.\n",
+      "These will keep the formatting within the string\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# f-strings work with triple quotes too.\n",
     "\n",
@@ -303,7 +475,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -327,9 +499,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'this is a really long string I need extended.'"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Extending multilined strings\n",
     "\n",
@@ -341,9 +524,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'I could also do this instead.'"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "long_string_2 = (\"I could also do \"\n",
     "                 \"this instead.\"\n",
@@ -363,9 +557,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello world\n"
+     ]
+    }
+   ],
    "source": [
     "# Format a print statement in a few ways\n",
     "\n",
@@ -374,18 +576,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello %s' % 'world\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"hello %s' % 'world\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "chips, candy, peanuts\n"
+     ]
+    }
+   ],
    "source": [
     "# You can unpack a list to format they will align numerically\n",
     "\n",
@@ -396,9 +614,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "candy, candy, candy\n",
+      "peanuts, candy, chips\n"
+     ]
+    }
+   ],
    "source": [
     "# You can also force indexes\n",
     "snacks = [\"chips\", \"candy\", \"peanuts\"]\n",
@@ -409,9 +636,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cat dog is a show\n"
+     ]
+    }
+   ],
    "source": [
     "# F strings allow you to put a variable by its name within a string. > Python 3.6\n",
     "\n",
@@ -423,9 +658,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello\n",
+      "\n",
+      "hello\\n\n"
+     ]
+    }
+   ],
    "source": [
     "# Raw strings will print out exactly what is in the string. \n",
     "# This is used in regex or regular expressions... import re\n",
@@ -437,9 +682,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'$1,234.54'"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Formatting money, this one is really useful!\n",
     "\n",
@@ -448,9 +704,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "34.0%\n"
+     ]
+    }
+   ],
    "source": [
     "# Formatting percents\n",
     "\n",
@@ -459,9 +723,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1000000\n",
+      "1000\n"
+     ]
+    }
+   ],
    "source": [
     "# Format numbers for readability\n",
     "\n",
@@ -484,9 +757,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'repr() shows it is a string by returning quotes'\n"
+     ]
+    }
+   ],
    "source": [
     "\"\"\"repr() computes the “official” string representation of an object.\n",
     "\n",
@@ -500,9 +781,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "str() doesn't return the quotes, we don't need know it's a string\n"
+     ]
+    }
+   ],
    "source": [
     "\"\"\"str() computes the “informal” string representation of an object\n",
     "\n",
@@ -516,9 +805,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'2022-08-22 21:15:33.936843'"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Another example\n",
     "\n",
@@ -529,9 +829,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'datetime.datetime(2022, 8, 22, 21, 15, 33, 975662)'"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "repr(datetime.datetime.now())  # repr shows where the object came from."
    ]
@@ -561,7 +872,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -586,9 +897,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0\n",
+      "5\n",
+      "10\n"
+     ]
+    }
+   ],
    "source": [
     "\"\"\"count(start=0, step=1)\n",
     "\n",
@@ -614,9 +935,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "A\n",
+      "B\n",
+      "C\n",
+      "D\n",
+      "A\n"
+     ]
+    }
+   ],
    "source": [
     "\"\"\"cycle(iterable)\n",
     "\n",
@@ -644,9 +977,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[10, 10, 10]\n",
+      "['hello', 'hello', 'hello', 'hello']\n"
+     ]
+    }
+   ],
    "source": [
     "\"\"\"repeat(object, times=None)\n",
     "\n",
@@ -661,9 +1003,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10\n"
+     ]
+    }
+   ],
    "source": [
     "repeat_obj = repeat(10, 3)\n",
     "\n",
@@ -688,9 +1038,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[1, 3, 6, 10, 15]"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "\"\"\"accumulate(iterable, func=operator.add)\n",
     "\n",
@@ -703,9 +1064,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n"
+     ]
+    }
+   ],
    "source": [
     "# Generator\n",
     "\n",
@@ -723,9 +1092,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['a', 'b', 'c', 'e', 'f', 'd', 'g', 'h', 'i', 'j', 'k', 'l']\n"
+     ]
+    }
+   ],
    "source": [
     "\"\"\"chain(*iterables)\n",
     "\n",
@@ -741,9 +1118,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a\n"
+     ]
+    }
+   ],
    "source": [
     "# Generator\n",
     "\n",
@@ -754,11 +1139,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 44,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['a', 'b', 'c', 'e', 'f', 'd', 'g', 'h', 'i', 'j', 'k', 'l']\n"
+     ]
+    }
+   ],
    "source": [
     "\"\"\"chain.from_interable(iterables)\n",
     "\n",
@@ -775,7 +1168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -795,9 +1188,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 46,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['A', 'C', 'E', 'F']"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "\"\"\"compress(data, selectors)\n",
     "\n",
@@ -814,11 +1218,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 47,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "A\n"
+     ]
+    }
+   ],
    "source": [
     "# Generator\n",
     "\n",
@@ -836,9 +1248,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 48,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[5, 6, 7, 8, 9]"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "\"\"\"dropwhile(predicate, iterable)\n",
     "\n",
@@ -861,9 +1284,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 49,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5\n"
+     ]
+    }
+   ],
    "source": [
     "# Generator\n",
     "\n",
@@ -881,9 +1312,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 50,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[0, 2, 4, 6, 8]"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "\"\"\"filterfalse(predicate, iterable)\n",
     "\n",
@@ -904,9 +1346,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 51,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0\n"
+     ]
+    }
+   ],
    "source": [
     "# Generator\n",
     "\n",
@@ -924,9 +1374,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 52,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['A', 'B', 'C', 'D', 'A', 'B']"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "\"\"\"groupby(iterable, key=None)\n",
     "\n",
@@ -947,9 +1408,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 53,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[['A', 'A', 'A', 'A'],\n",
+       " ['B', 'B', 'B'],\n",
+       " ['C', 'C'],\n",
+       " ['D'],\n",
+       " ['A', 'A'],\n",
+       " ['B', 'B', 'B']]"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Using groupby like this will return the groups\n",
     "\n",
@@ -965,9 +1442,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 54,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['A', 'B']\n",
+      "['A', 'B']\n"
+     ]
+    }
+   ],
    "source": [
     "\"\"\"islice(iterable, *args)\n",
     "\n",
@@ -983,9 +1469,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 55,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['C', 'D']\n",
+      "['C', 'D']\n"
+     ]
+    }
+   ],
    "source": [
     "print(list(islice(\"ABCDEFG\", 2, 4)))\n",
     "\n",
@@ -996,9 +1491,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 56,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['C', 'D', 'E', 'F', 'G']\n",
+      "['C', 'D', 'E', 'F', 'G']\n"
+     ]
+    }
+   ],
    "source": [
     "print(list(islice(\"ABCDEFG\", 2, None)))\n",
     "\n",
@@ -1009,9 +1513,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 57,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['A', 'C', 'E', 'G']\n",
+      "['A', 'C', 'E', 'G']\n"
+     ]
+    }
+   ],
    "source": [
     "print(list(islice(\"ABCDEFG\", 0, None, 2)))\n",
     "\n",
@@ -1029,9 +1542,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 58,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[32, 9, 1000]\n",
+      "[32, 9, 1000]\n"
+     ]
+    }
+   ],
    "source": [
     "\"\"\"starmap(function, iterable)\n",
     "\n",
@@ -1051,11 +1573,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 59,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "32\n"
+     ]
+    }
+   ],
    "source": [
     "starmap_obj = starmap(pow, [(2,5), (3,2), (10,3)])\n",
     "\n",
@@ -1071,11 +1601,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 60,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[1, 4]"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "\"\"\"takewhile(predicate, iterable)\n",
     "\n",
@@ -1088,9 +1629,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 61,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n"
+     ]
+    }
+   ],
    "source": [
     "takewhile_obj = takewhile(lambda x: x<5, [1, 4, 6, 4, 1])\n",
     "\n",
@@ -1106,14 +1655,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 62,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(<itertools._tee object at 0x7ff1fd54fb40>, <itertools._tee object at 0x7ff1fd54f200>, <itertools._tee object at 0x7ff1fd54fd40>)\n"
+      "(<itertools._tee object at 0x7fe158635380>, <itertools._tee object at 0x7fe158635440>, <itertools._tee object at 0x7fe158635480>)\n"
      ]
     }
    ],
@@ -1131,7 +1680,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [
     {
@@ -1165,9 +1714,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 64,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[('A', 'x'), ('B', 'y'), ('C', '-'), ('D', '-')]\n",
+      "[('A', 'x'), ('B', 'y'), ('C', 'z'), ('D', '-')]\n",
+      "[('A', 'x'), ('B', 'y'), ('C', 'z'), ('D', 'a'), ('-', 'b')]\n"
+     ]
+    }
+   ],
    "source": [
     "\"\"\"zip_longest(*iterables, fillvalue=None)\n",
     "\n",
@@ -1187,9 +1746,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 65,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('A', 'x')\n"
+     ]
+    }
+   ],
    "source": [
     "zip_longest_obj = zip_longest(\"ABCD\", \"xy\", fillvalue=\"-\")\n",
     "\n",
@@ -1214,9 +1781,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 66,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('A',), ('B',), ('C',), ('D',)]"
+      ]
+     },
+     "execution_count": 66,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "\"\"\"Product (*iterables, repeat=1)\n",
     "\n",
@@ -1232,18 +1810,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 67,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('A', 'A'),\n",
+       " ('A', 'B'),\n",
+       " ('A', 'C'),\n",
+       " ('A', 'D'),\n",
+       " ('B', 'A'),\n",
+       " ('B', 'B'),\n",
+       " ('B', 'C'),\n",
+       " ('B', 'D'),\n",
+       " ('C', 'A'),\n",
+       " ('C', 'B'),\n",
+       " ('C', 'C'),\n",
+       " ('C', 'D'),\n",
+       " ('D', 'A'),\n",
+       " ('D', 'B'),\n",
+       " ('D', 'C'),\n",
+       " ('D', 'D')]"
+      ]
+     },
+     "execution_count": 67,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "list(product(\"ABCD\", repeat=2))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 68,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('A',)\n"
+     ]
+    }
+   ],
    "source": [
     "product_object = product(\"ABCD\", repeat=1)\n",
     "\n",
@@ -1259,11 +1871,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 69,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('A', 'B'),\n",
+       " ('A', 'C'),\n",
+       " ('A', 'D'),\n",
+       " ('B', 'A'),\n",
+       " ('B', 'C'),\n",
+       " ('B', 'D'),\n",
+       " ('C', 'A'),\n",
+       " ('C', 'B'),\n",
+       " ('C', 'D'),\n",
+       " ('D', 'A'),\n",
+       " ('D', 'B'),\n",
+       " ('D', 'C')]"
+      ]
+     },
+     "execution_count": 69,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "\"\"\"permutations(iterable, r=None_\n",
     "\n",
@@ -1277,9 +1911,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 70,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('A', 'B')\n"
+     ]
+    }
+   ],
    "source": [
     "permutation_obj = permutations(\"ABCD\", 2)\n",
     "\n",
@@ -1295,9 +1937,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 71,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('A', 'B'), ('A', 'C'), ('A', 'D'), ('B', 'C'), ('B', 'D'), ('C', 'D')]"
+      ]
+     },
+     "execution_count": 71,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "\"\"\"combinations(iterable, r)\n",
     "\n",
@@ -1312,9 +1965,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 72,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('A', 'B')\n"
+     ]
+    }
+   ],
    "source": [
     "combinations_obj = combinations(\"ABCD\", 2)\n",
     "\n",
@@ -1330,16 +1991,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 73,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('A', 'A'),\n",
+       " ('A', 'B'),\n",
+       " ('A', 'C'),\n",
+       " ('A', 'D'),\n",
+       " ('B', 'B'),\n",
+       " ('B', 'C'),\n",
+       " ('B', 'D'),\n",
+       " ('C', 'C'),\n",
+       " ('C', 'D'),\n",
+       " ('D', 'D')]"
+      ]
+     },
+     "execution_count": 73,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "\"\"\"combinations_with_replacement(iterable, r)\n",
     "\n",
     "Returns all combinations with replacements,\n",
     "Results in sorted order\n",
+    "r represents the size/length of different combinations that are possible\n",
     "\n",
     "The list should return with these additional elements:\n",
     "[(\"A\", \"A\"), (\"B\", \"B\"), (\"C\", \"C\"), (\"D\", \"D\")]\n",
@@ -1352,9 +2034,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 74,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('A', 'A')\n"
+     ]
+    }
+   ],
    "source": [
     "combinations_replace_obj = combinations_with_replacement(\"ABCD\", 2)\n",
     "\n",
@@ -1379,7 +2069,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 75,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1395,15 +2085,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 76,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Color(red=255, green=255, blue=224)\n"
+     ]
+    }
+   ],
    "source": [
-    "\"\"\"namedtuple(typename, field_names, verbose=False, rename=False)\n",
+    "\"\"\"namedtuple(typename, field_names, rename=False) # verbose=False argument was removed in Python 3.7\n",
     "\n",
-    "Used to create tuple-like objects that act like lists\n",
-    "dictionaries. Very good at being descriptive check.\n",
+    "A factory function used to create tuple-like IMMUTABLE objects that act like lists\n",
+    "dictionaries. Use named tuples instead of tuples anywhere \n",
+    "you think object notation will make your code more easily readable.\n",
+    "Note that the the VALUES they store don’t have to be immutable\n",
+    "but attributes in named tuples are immutable.\n",
     "\n",
+    "\n",
+    "required arguments:\n",
+    "\n",
+    "typename    - the class name represented as a string\n",
+    "field_names - the field names you'll use to access the tuple values\n",
+    "                - can be an iterable of strings\n",
+    "                - can be a string with values separated by white space\n",
+    "                - can be a string with values separated by commas\n",
+    "\n",
+    "optional arguments:\n",
+    "\n",
+    "rename   - if set to true, all invalid field names are replaced with positional names\n",
+    "defaults - defaulted to None, which means field names won't have default values. Can \n",
+    "           be set to an iterable of values\n",
+    "module   - the .__module__ attribute of the resulting namedtuple is set to this given value\n",
+    "           \n",
+    "\n",
+    "named tuple methods:\n",
     "._make          creates list like tuple\n",
     "\n",
     "._asdict()      creates dict like tuple\n",
@@ -1424,7 +2143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 77,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1433,9 +2152,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 78,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "255"
+      ]
+     },
+     "execution_count": 78,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Indexable\n",
     "\n",
@@ -1444,11 +2174,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 79,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "255"
+      ]
+     },
+     "execution_count": 79,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Key accessable\n",
     "\n",
@@ -1461,9 +2202,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 80,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "descriptor(x=11, y=22)\n",
+      "descriptor(x=11, y=22)\n"
+     ]
+    }
+   ],
    "source": [
     "# These create list like objects, iterable and indexable.\n",
     "\n",
@@ -1481,9 +2231,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 81,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "descriptor(x=33, y=22)"
+      ]
+     },
+     "execution_count": 81,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# ._replace \n",
     "\n",
@@ -1493,9 +2254,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 82,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('x', 'y')"
+      ]
+     },
+     "execution_count": 82,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# ._fields\n",
     "\n",
@@ -1511,9 +2283,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 83,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "deque([1, 2, 3])\n"
+     ]
+    }
+   ],
    "source": [
     "\"\"\"deque([iterable[, maxlen]])\n",
     "\n",
@@ -1570,9 +2350,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 84,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "deque([1, 2, 3, 4])\n"
+     ]
+    }
+   ],
    "source": [
     "# append()\n",
     "\n",
@@ -1583,9 +2371,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 85,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "deque([0, 1, 2, 3, 4])\n"
+     ]
+    }
+   ],
    "source": [
     "# appendleft()\n",
     "\n",
@@ -1596,9 +2392,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 86,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "deque([])\n"
+     ]
+    }
+   ],
    "source": [
     "# clear()\n",
     "\n",
@@ -1609,9 +2413,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 87,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "deque([1, 2, 3])\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 87,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# count()\n",
     "d = deque([1, 2, 3])\n",
@@ -1623,9 +2445,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 88,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "deque([1, 2, 3, 4, 5, 6])\n"
+     ]
+    }
+   ],
    "source": [
     "# entend()\n",
     "\n",
@@ -1636,9 +2466,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 89,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "deque([-2, -1, 0, 1, 2, 3, 4, 5, 6])\n"
+     ]
+    }
+   ],
    "source": [
     "# extendleft()\n",
     "\n",
@@ -1649,9 +2487,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 90,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6\n",
+      "deque([-2, -1, 0, 1, 2, 3, 4, 5])\n"
+     ]
+    }
+   ],
    "source": [
     "# pop()\n",
     "\n",
@@ -1662,9 +2509,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 91,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-2\n",
+      "deque([-1, 0, 1, 2, 3, 4, 5])\n"
+     ]
+    }
+   ],
    "source": [
     "# popleft()\n",
     "\n",
@@ -1675,9 +2531,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 92,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "deque([-1, 0, 1, 2, 3, 4, 5])\n",
+      "deque([-1, 0, 1, 2, 3, 4])\n"
+     ]
+    }
+   ],
    "source": [
     "# remove()\n",
     "\n",
@@ -1690,9 +2555,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 93,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "deque([-1, 0, 1, 2, 3, 4])\n",
+      "deque([4, 3, 2, 1, 0, -1])\n"
+     ]
+    }
+   ],
    "source": [
     "# reverse()\n",
     "\n",
@@ -1705,9 +2579,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 94,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "deque([4, 3, 2, 1, 0, -1])\n",
+      "deque([-1, 4, 3, 2, 1, 0])\n",
+      "deque([4, 3, 2, 1, 0, -1])\n"
+     ]
+    }
+   ],
    "source": [
     "# rotate(n) # You can adjust n\n",
     "\n",
@@ -1731,45 +2615,66 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 95,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{'a': 1, 'b': 2, 'c': 3}, {'c': 4, 'd': 5, 'e': 6}]\n"
+     ]
+    }
+   ],
    "source": [
     "\"\"\"ChainMap(*maps)\n",
     "\n",
     "A ChainMap class is provided for quickly linking\n",
     "a number of mappings so they can be treated as a single unit.\n",
     "\n",
-    "If there a key that is the same within the ChainMap object, \n",
-    "it will assign the value to the first instance of that key.\n",
+    "Identical keys within the ChainMap object will all have\n",
+    "the value of the first instance of that key.\n",
     "\"\"\"\n",
     "\n",
     "dict1 = {\"a\":1, \"b\":2, \"c\":3}\n",
     "dict2 = {\"c\":4, \"d\":5, \"e\":6}\n",
     "\n",
-    "chained = ChainMap(dict1,dict2)"
+    "chained = ChainMap(dict1,dict2)\n",
+    "print(chained.maps) #maps operation displays keys and values"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 96,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['c', 'd', 'e', 'a', 'b']\n"
+     ]
+    }
+   ],
    "source": [
-    "chained[\"b\"]"
+    "print(list(chained.keys())) #keys operation displays keys"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
+   "execution_count": 97,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[3, 5, 6, 1, 2]\n"
+     ]
+    }
+   ],
    "source": [
-    "# Assigned 3 not 4 because dict1 was paased first.\n",
-    "\n",
-    "chained[\"c\"]"
+    "print (list(chained.values())) #values operation displays values"
    ]
   },
   {
@@ -1781,9 +2686,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 98,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Counter({1: 3, 2: 3, 3: 3, 5: 3, 7: 3, 4: 3, 9: 3})"
+      ]
+     },
+     "execution_count": 98,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "\"\"\"Counter([iterable-or-mapping])\n",
     "\n",
@@ -1809,7 +2725,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 99,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1817,6 +2733,8 @@
     "\n",
     "An OrderedDict is a dict that remembers\n",
     "the order that keys were first inserted.\n",
+    "If a new entry overwrites an existing entry,\n",
+    "the order is left unchanged.\n",
     "\"\"\"\n",
     "\n",
     "ordered_dict = OrderedDict({\"a\":1, \"b\":2, \"c\":3, \"d\":4})"
@@ -1824,18 +2742,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 100,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OrderedDict([('a', 1), ('b', 2), ('c', 3), ('d', 4)])"
+      ]
+     },
+     "execution_count": 100,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "ordered_dict"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 101,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a 1\n",
+      "b 2\n",
+      "c 3\n",
+      "d 4\n"
+     ]
+    }
+   ],
    "source": [
     "# Supports all dictionary functions.\n",
     "\n",
@@ -1852,9 +2792,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 102,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'m': 1, 'i': 4, 's': 4, 'p': 2}\n",
+      "[('m', 1), ('i', 4), ('s', 4), ('p', 2)]\n"
+     ]
+    }
+   ],
    "source": [
     "\"\"\"defaultdict([default_factory[, ...]])\n",
     "\n",
@@ -1888,9 +2837,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 103,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('yellow', [1, 3]), ('blue', [2, 4]), ('red', [1])]"
+      ]
+     },
+     "execution_count": 103,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Setting the default to a list.\n",
     "\n",
@@ -1911,23 +2871,20 @@
     "### Functools<a id='functools'></a>\n",
     "[Return to table of contents](#toc)\n",
     "\n",
-    "The functools module is for higher-order functions: functions that act on or return other functions. In general, any callable object can be treated as a function for the purposes of this module.\n",
+    "The functools module is for higher-order functions: functions that act on or return other functions. In general, any callable object can be treated as a function for the purposes of this module. Functools has a lot of wrapper tools and functionality. Partial and reduce are very good to know. I may add more to this section later.\n",
     "\n",
     "https://docs.python.org/3/library/functools.html#functools.partial"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 104,
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
-    "from functools import *\n",
-    "\n",
-    "\"\"\"Functools has a lot of wrapper tools and functionality. \n",
-    "I may go over them at some point. For now I think partial and reduce\n",
-    "are very good to know.\n",
-    "\"\"\""
+    "from functools import *"
    ]
   },
   {
@@ -1939,7 +2896,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 105,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1960,9 +2917,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 106,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Joe Smith 10\n"
+     ]
+    }
+   ],
    "source": [
     "freshman(\"Joe\", \"Smith\")"
    ]
@@ -1976,9 +2941,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 107,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "False\n",
+      "True\n"
+     ]
+    }
+   ],
    "source": [
     "\"\"\"partialmethod(func, *args, **keywords)\n",
     "\n",
@@ -2015,18 +2989,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 108,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3628800"
+      ]
+     },
+     "execution_count": 108,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "\"\"\"reduce(function, iterable, initializer=None)\n",
     "\n",
     "Reduce needs to be imported in Python3.x\n",
     "\n",
-    "Reduce is a really useful function for performing some computation on a list and returning the result.\n",
+    "Reduce is a useful function for performing some computation on a list and returning the result.\n",
     "It applies a rolling computation to sequential pairs of values in a list. This one is tricky.\n",
     "\n",
-    "Easiest example to understnad is trying to multiply a whole list together i.e 1*2*3*4*5*6*7*8*9*10\n",
+    "Easiest example to understand is trying to multiply a whole list together like shown below \n",
+    "i.e 1*2*3*4*5*6*7*8*9*10\n",
     "\"\"\"\n",
     "\n",
     "list_1 = list(range(1,11))\n",
@@ -2036,9 +3022,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 109,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10"
+      ]
+     },
+     "execution_count": 109,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Another great example is using reduce to compare elements in a list against each other.\n",
     "\n",
@@ -2047,11 +3044,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 110,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 110,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "reduce(lambda x, y: y if y < x else x, list_1) # Finding the smallest number in the list"
    ]
@@ -2065,9 +3073,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 111,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'lru_cache(maxsize=128, typed=False)\\n\\nDecorator to wrap a function with a memoizing callable that saves up to the maxsize most recent calls.\\n'"
+      ]
+     },
+     "execution_count": 111,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "\"\"\"lru_cache(maxsize=128, typed=False)\n",
     "\n",
@@ -2077,7 +3096,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 112,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2092,7 +3111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 113,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2116,7 +3135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 114,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2146,7 +3165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 115,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2155,9 +3174,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 116,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "datetime.datetime(2022, 8, 22, 21, 15, 35, 126432)"
+      ]
+     },
+     "execution_count": 116,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "\"\"\"datetime()\n",
     "\n",
@@ -2171,11 +3201,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 117,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Today is the 22 day of month 8, and the year is 2022!\n"
+     ]
+    }
+   ],
    "source": [
     "now = datetime.now()\n",
     "\n",
@@ -2197,9 +3235,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 118,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The current month is August.\n"
+     ]
+    }
+   ],
    "source": [
     "\"\"\"strftime() \n",
     "\n",
@@ -2217,9 +3263,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 119,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Today's date is 22-08-2022. Be careful; It's not a datetimeobject anymore it is a <class 'str'>!\n"
+     ]
+    }
+   ],
    "source": [
     "# strftime() can generally be used to format datetime objects.\n",
     "\n",
@@ -2237,11 +3291,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 120,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "I started studying in university back in 21-10-2015\n",
+      "and I'll finish in 17-10-2018\n"
+     ]
+    }
+   ],
    "source": [
     "\"\"\"timedelta()\n",
     "Used to get a date X days\\months\\etc from now.\n",
@@ -2277,7 +3340,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 121,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2286,7 +3349,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 122,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2297,7 +3360,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 123,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2308,16 +3371,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 124,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['LICENSE.md',\n",
+       " 'random_tips.ipynb',\n",
+       " 'functions_and_classes.ipynb',\n",
+       " 'built_in_functions_and_libraries.ipynb',\n",
+       " '.gitignore',\n",
+       " '.ipynb_checkpoints',\n",
+       " 'general_tips.ipynb',\n",
+       " 'README.rst',\n",
+       " '.git']"
+      ]
+     },
+     "execution_count": 124,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "os.listdir() # Shows what files are in your directory. Equivalent to: ls -a"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 125,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2330,7 +3412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 126,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2343,7 +3425,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 127,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2354,7 +3436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 128,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2376,7 +3458,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 129,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2387,9 +3469,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 130,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'python_tips'"
+      ]
+     },
+     "execution_count": 130,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# This should remove everything except the name of the directory this file is located.\n",
     "\n",
@@ -2398,7 +3491,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 131,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2409,7 +3502,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 132,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2420,9 +3513,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 133,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 133,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Used to check if a path exists.\n",
     "\n",
@@ -2431,9 +3535,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 134,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 134,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Used to check if something is a dir.\n",
     "\n",
@@ -2442,9 +3557,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 135,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 135,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Used to check if something is a file.\n",
     "\n",
@@ -2453,9 +3579,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 136,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('file', '.txt')"
+      ]
+     },
+     "execution_count": 136,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# # Useful for handling extensions.\n",
     "\n",

--- a/built_in_functions_and_libraries.ipynb
+++ b/built_in_functions_and_libraries.ipynb
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,20 +79,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[12, 14, 16, 18, 20, 22, 24, 26, 28, 30]"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Using a standard function.\n",
     "\n",
@@ -101,20 +90,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[12, 14, 16, 18, 20, 22, 24, 26, 28, 30]"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Using a lambda function.\n",
     "\n",
@@ -133,40 +111,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "list_1"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[6, 7, 8, 9, 10]"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Filter for elements greater than 5\n",
     "\n",
@@ -185,20 +141,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'Tim': 'dog', 'Steve': 'cat', 'Matt': 'sheep'}"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Very useful when making a dictionary\n",
     "\n",
@@ -210,20 +155,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[('Tim', 'dog'), ('Steve', 'cat'), ('Matt', 'sheep')]"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Will make a tuple by default\n",
     "\n",
@@ -232,20 +166,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<zip at 0x104c902c8>"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# It will return as an object so you need a list() or dict() call to return anything\n",
     "zip(animal_names, animals)"
@@ -253,17 +176,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'a': 1, 'b': 2, 'c': 3, 'd': 4}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Quick way to zip dictionaries\n",
     "\n",
@@ -284,28 +199,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1\n",
-      "2\n",
-      "3\n",
-      "4\n",
-      "5\n",
-      "6\n",
-      "7\n",
-      "8\n",
-      "9\n",
-      "10\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Standard for loop print:\n",
     "for i in list_1:\n",
@@ -314,17 +212,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1 2 3 4 5 6 7 8 9 10 "
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# For loop printing on the same line\n",
     "\n",
@@ -334,17 +224,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1 2 3 4 5 6 7 8 9 10\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Quickest way of unpacking of a list, although it prints on the same line.\n",
     "print(*list_1)"
@@ -352,26 +234,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1\n",
-      "2\n",
-      "3\n",
-      "4\n",
-      "5\n",
-      "6\n",
-      "7\n",
-      "8\n",
-      "9\n",
-      "10\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Quicker way than a for loop with a new line.\n",
     "print(*list_1, sep=\"\\n\") "
@@ -390,37 +255,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "I'm using an apostrophe\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"I'm using an apostrophe\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Use triple quotes for these\n",
-      "Or these\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print('''Use triple quotes for these''')\n",
     "\n",
@@ -429,19 +277,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "These are very useful you can use .format on this too.\n",
-      "These will keep the formatting within the string\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print('''These are very useful you can use {} on this too.\n",
     "These will keep the formatting within the string\n",
@@ -450,19 +288,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "These are very useful you can use f-strings on this too.\n",
-      "These will keep the formatting within the string\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# f-strings work with triple quotes too.\n",
     "\n",
@@ -475,7 +303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -499,20 +327,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'this is a really long string I need extended.'"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Extending multilined strings\n",
     "\n",
@@ -524,20 +341,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'I could also do this instead.'"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "long_string_2 = (\"I could also do \"\n",
     "                 \"this instead.\"\n",
@@ -557,17 +363,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "hello world\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Format a print statement in a few ways\n",
     "\n",
@@ -576,34 +374,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "hello %s' % 'world\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"hello %s' % 'world\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "chips, candy, peanuts\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# You can unpack a list to format they will align numerically\n",
     "\n",
@@ -614,18 +396,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "candy, candy, candy\n",
-      "peanuts, candy, chips\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# You can also force indexes\n",
     "snacks = [\"chips\", \"candy\", \"peanuts\"]\n",
@@ -636,17 +409,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "cat dog is a show\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# F strings allow you to put a variable by its name within a string. > Python 3.6\n",
     "\n",
@@ -658,19 +423,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "hello\n",
-      "\n",
-      "hello\\n\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Raw strings will print out exactly what is in the string. \n",
     "# This is used in regex or regular expressions... import re\n",
@@ -682,20 +437,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'$1,234.54'"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Formatting money, this one is really useful!\n",
     "\n",
@@ -704,17 +448,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "34.0%\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Formatting percents\n",
     "\n",
@@ -723,18 +459,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1000000\n",
-      "1000\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Format numbers for readability\n",
     "\n",
@@ -757,17 +484,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "'repr() shows it is a string by returning quotes'\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"repr() computes the “official” string representation of an object.\n",
     "\n",
@@ -781,17 +500,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "str() doesn't return the quotes, we don't need know it's a string\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"str() computes the “informal” string representation of an object\n",
     "\n",
@@ -805,20 +516,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'2020-02-04 10:43:54.614899'"
-      ]
-     },
-     "execution_count": 33,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Another example\n",
     "\n",
@@ -829,20 +529,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'datetime.datetime(2020, 2, 4, 10, 43, 54, 629390)'"
-      ]
-     },
-     "execution_count": 34,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "repr(datetime.datetime.now())  # repr shows where the object came from."
    ]
@@ -872,11 +561,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from itertools import *"
+    "from itertools import * #does not work"
    ]
   },
   {
@@ -897,19 +586,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0\n",
-      "5\n",
-      "10\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"count(start=0, step=1)\n",
     "\n",
@@ -935,21 +614,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "A\n",
-      "B\n",
-      "C\n",
-      "D\n",
-      "A\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"cycle(iterable)\n",
     "\n",
@@ -977,18 +644,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[10, 10, 10]\n",
-      "['hello', 'hello', 'hello', 'hello']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"repeat(object, times=None)\n",
     "\n",
@@ -1003,17 +661,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "10\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "repeat_obj = repeat(10, 3)\n",
     "\n",
@@ -1038,20 +688,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[1, 3, 6, 10, 15]"
-      ]
-     },
-     "execution_count": 40,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"accumulate(iterable, func=operator.add)\n",
     "\n",
@@ -1064,17 +703,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Generator\n",
     "\n",
@@ -1092,17 +723,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['a', 'b', 'c', 'f', 'e', 'd', 'g', 'h', 'i', 'j', 'k', 'l']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"chain(*iterables)\n",
     "\n",
@@ -1118,17 +741,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "a\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Generator\n",
     "\n",
@@ -1139,19 +754,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['a', 'b', 'c', 'f', 'e', 'd', 'g', 'h', 'i', 'j', 'k', 'l']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"chain.from_interable(iterables)\n",
     "\n",
@@ -1168,7 +775,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1188,20 +795,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['A', 'C', 'E', 'F']"
-      ]
-     },
-     "execution_count": 46,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"compress(data, selectors)\n",
     "\n",
@@ -1218,19 +814,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "A\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Generator\n",
     "\n",
@@ -1248,20 +836,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[5, 6, 7, 8, 9]"
-      ]
-     },
-     "execution_count": 48,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"dropwhile(predicate, iterable)\n",
     "\n",
@@ -1284,17 +861,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "5\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Generator\n",
     "\n",
@@ -1312,20 +881,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[0, 2, 4, 6, 8]"
-      ]
-     },
-     "execution_count": 50,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"filterfalse(predicate, iterable)\n",
     "\n",
@@ -1346,17 +904,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Generator\n",
     "\n",
@@ -1374,20 +924,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['A', 'B', 'C', 'D', 'A', 'B']"
-      ]
-     },
-     "execution_count": 52,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"groupby(iterable, key=None)\n",
     "\n",
@@ -1408,25 +947,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[['A', 'A', 'A', 'A'],\n",
-       " ['B', 'B', 'B'],\n",
-       " ['C', 'C'],\n",
-       " ['D'],\n",
-       " ['A', 'A'],\n",
-       " ['B', 'B', 'B']]"
-      ]
-     },
-     "execution_count": 53,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Using groupby like this will return the groups\n",
     "\n",
@@ -1442,18 +965,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['A', 'B']\n",
-      "['A', 'B']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"islice(iterable, *args)\n",
     "\n",
@@ -1469,18 +983,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['C', 'D']\n",
-      "['C', 'D']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(list(islice(\"ABCDEFG\", 2, 4)))\n",
     "\n",
@@ -1491,18 +996,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['C', 'D', 'E', 'F', 'G']\n",
-      "['C', 'D', 'E', 'F', 'G']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(list(islice(\"ABCDEFG\", 2, None)))\n",
     "\n",
@@ -1513,18 +1009,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['A', 'C', 'E', 'G']\n",
-      "['A', 'C', 'E', 'G']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(list(islice(\"ABCDEFG\", 0, None, 2)))\n",
     "\n",
@@ -1542,18 +1029,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[32, 9, 1000]\n",
-      "[32, 9, 1000]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"starmap(function, iterable)\n",
     "\n",
@@ -1573,19 +1051,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "32\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "starmap_obj = starmap(pow, [(2,5), (3,2), (10,3)])\n",
     "\n",
@@ -1601,22 +1071,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[1, 4]"
-      ]
-     },
-     "execution_count": 60,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"takewhile(predicate, iterable)\n",
     "\n",
@@ -1629,17 +1088,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "takewhile_obj = takewhile(lambda x: x<5, [1, 4, 6, 4, 1])\n",
     "\n",
@@ -1655,14 +1106,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(<itertools._tee object at 0x104ce6bc8>, <itertools._tee object at 0x104ce4bc8>, <itertools._tee object at 0x104ce4c48>)\n"
+      "(<itertools._tee object at 0x7ff1fd54fb40>, <itertools._tee object at 0x7ff1fd54f200>, <itertools._tee object at 0x7ff1fd54fd40>)\n"
      ]
     }
    ],
@@ -1672,88 +1123,37 @@
     "Tee will take the iterable that you give it \n",
     "and return a tuple of n iterables, which you can then iterate through. \n",
     "\"\"\"\n",
+    "b = tee((1,2,3,4), 3)\n",
+    "print(b) #outputs ([1,2,3,4], [1,2,3,4], [1,2,3,4])\n",
     "\n",
-    "b = tee((1, 2, 3, 4), 3)  # Created 3 iterable object with the same elements\n",
-    "print(b)"
+    "# b = itertools.tee((1,2,3,4), 3) outputs the same thing as above"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1\n",
-      "2\n",
-      "3\n",
-      "4\n"
+      "[1, 2, 3, 4]\n",
+      "[1, 2, 3, 4]\n",
+      "[1, 2, 3, 4]\n",
+      "[]\n",
+      "[]\n",
+      "[]\n"
      ]
     }
    ],
    "source": [
-    "for first in b[0]:\n",
-    "    print(first)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 64,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1\n",
-      "2\n",
-      "3\n",
-      "4\n"
-     ]
-    }
-   ],
-   "source": [
-    "for second in b[1]:\n",
-    "    print(second)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 65,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1\n",
-      "2\n",
-      "3\n",
-      "4\n"
-     ]
-    }
-   ],
-   "source": [
-    "for third in b[2]:\n",
-    "    print(third)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 66,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Will raise IndexError uncomment to run.\n",
-    "\n",
-    "# for third in b[3]:\n",
-    "#     print(third)"
+    "# Created 3 iterable object with the same elements\n",
+    "for i in range(0,3):\n",
+    "    print(list(b[i]))\n",
+    "for i in range(0,3): #Remember they are iterators so they're designed to generate data exactly one time. \n",
+    "    print(list(b[i]))#If you want to get data out of it a second time, you either have to save \n",
+    "                     #all the iterated data to another list, or initiate the iterator again."
    ]
   },
   {
@@ -1765,19 +1165,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[('A', 'x'), ('B', 'y'), ('C', '-'), ('D', '-')]\n",
-      "[('A', 'x'), ('B', 'y'), ('C', 'z'), ('D', '-')]\n",
-      "[('A', 'x'), ('B', 'y'), ('C', 'z'), ('D', 'a'), ('-', 'b')]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"zip_longest(*iterables, fillvalue=None)\n",
     "\n",
@@ -1797,17 +1187,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "('A', 'x')\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "zip_longest_obj = zip_longest(\"ABCD\", \"xy\", fillvalue=\"-\")\n",
     "\n",
@@ -1832,20 +1214,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[('A',), ('B',), ('C',), ('D',)]"
-      ]
-     },
-     "execution_count": 69,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"Product (*iterables, repeat=1)\n",
     "\n",
@@ -1861,52 +1232,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[('A', 'A'),\n",
-       " ('A', 'B'),\n",
-       " ('A', 'C'),\n",
-       " ('A', 'D'),\n",
-       " ('B', 'A'),\n",
-       " ('B', 'B'),\n",
-       " ('B', 'C'),\n",
-       " ('B', 'D'),\n",
-       " ('C', 'A'),\n",
-       " ('C', 'B'),\n",
-       " ('C', 'C'),\n",
-       " ('C', 'D'),\n",
-       " ('D', 'A'),\n",
-       " ('D', 'B'),\n",
-       " ('D', 'C'),\n",
-       " ('D', 'D')]"
-      ]
-     },
-     "execution_count": 70,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "list(product(\"ABCD\", repeat=2))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "('A',)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "product_object = product(\"ABCD\", repeat=1)\n",
     "\n",
@@ -1922,33 +1259,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[('A', 'B'),\n",
-       " ('A', 'C'),\n",
-       " ('A', 'D'),\n",
-       " ('B', 'A'),\n",
-       " ('B', 'C'),\n",
-       " ('B', 'D'),\n",
-       " ('C', 'A'),\n",
-       " ('C', 'B'),\n",
-       " ('C', 'D'),\n",
-       " ('D', 'A'),\n",
-       " ('D', 'B'),\n",
-       " ('D', 'C')]"
-      ]
-     },
-     "execution_count": 72,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"permutations(iterable, r=None_\n",
     "\n",
@@ -1962,17 +1277,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "('A', 'B')\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "permutation_obj = permutations(\"ABCD\", 2)\n",
     "\n",
@@ -1988,20 +1295,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[('A', 'B'), ('A', 'C'), ('A', 'D'), ('B', 'C'), ('B', 'D'), ('C', 'D')]"
-      ]
-     },
-     "execution_count": 74,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"combinations(iterable, r)\n",
     "\n",
@@ -2016,17 +1312,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "('A', 'B')\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "combinations_obj = combinations(\"ABCD\", 2)\n",
     "\n",
@@ -2042,31 +1330,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[('A', 'A'),\n",
-       " ('A', 'B'),\n",
-       " ('A', 'C'),\n",
-       " ('A', 'D'),\n",
-       " ('B', 'B'),\n",
-       " ('B', 'C'),\n",
-       " ('B', 'D'),\n",
-       " ('C', 'C'),\n",
-       " ('C', 'D'),\n",
-       " ('D', 'D')]"
-      ]
-     },
-     "execution_count": 76,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"combinations_with_replacement(iterable, r)\n",
     "\n",
@@ -2084,17 +1352,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "('A', 'A')\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "combinations_replace_obj = combinations_with_replacement(\"ABCD\", 2)\n",
     "\n",
@@ -2119,7 +1379,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2135,17 +1395,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Color(red=255, green=255, blue=224)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"namedtuple(typename, field_names, verbose=False, rename=False)\n",
     "\n",
@@ -2172,7 +1424,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2181,20 +1433,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "255"
-      ]
-     },
-     "execution_count": 81,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Indexable\n",
     "\n",
@@ -2203,22 +1444,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "255"
-      ]
-     },
-     "execution_count": 82,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Key accessable\n",
     "\n",
@@ -2231,18 +1461,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "descriptor(x=11, y=22)\n",
-      "descriptor(x=11, y=22)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# These create list like objects, iterable and indexable.\n",
     "\n",
@@ -2260,20 +1481,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "descriptor(x=33, y=22)"
-      ]
-     },
-     "execution_count": 84,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# ._replace \n",
     "\n",
@@ -2283,20 +1493,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "('x', 'y')"
-      ]
-     },
-     "execution_count": 85,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# ._fields\n",
     "\n",
@@ -2312,17 +1511,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "deque([1, 2, 3])\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"deque([iterable[, maxlen]])\n",
     "\n",
@@ -2379,17 +1570,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "deque([1, 2, 3, 4])\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# append()\n",
     "\n",
@@ -2400,17 +1583,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "deque([0, 1, 2, 3, 4])\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# appendleft()\n",
     "\n",
@@ -2421,17 +1596,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "deque([])\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# clear()\n",
     "\n",
@@ -2442,27 +1609,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "deque([1, 2, 3])\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "1"
-      ]
-     },
-     "execution_count": 90,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# count()\n",
     "d = deque([1, 2, 3])\n",
@@ -2474,17 +1623,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "deque([1, 2, 3, 4, 5, 6])\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# entend()\n",
     "\n",
@@ -2495,17 +1636,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "deque([-2, -1, 0, 1, 2, 3, 4, 5, 6])\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# extendleft()\n",
     "\n",
@@ -2516,18 +1649,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "6\n",
-      "deque([-2, -1, 0, 1, 2, 3, 4, 5])\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# pop()\n",
     "\n",
@@ -2538,18 +1662,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "-2\n",
-      "deque([-1, 0, 1, 2, 3, 4, 5])\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# popleft()\n",
     "\n",
@@ -2560,18 +1675,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "deque([-1, 0, 1, 2, 3, 4, 5])\n",
-      "deque([-1, 0, 1, 2, 3, 4])\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# remove()\n",
     "\n",
@@ -2584,18 +1690,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "deque([-1, 0, 1, 2, 3, 4])\n",
-      "deque([4, 3, 2, 1, 0, -1])\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# reverse()\n",
     "\n",
@@ -2608,19 +1705,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "deque([4, 3, 2, 1, 0, -1])\n",
-      "deque([-1, 4, 3, 2, 1, 0])\n",
-      "deque([4, 3, 2, 1, 0, -1])\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# rotate(n) # You can adjust n\n",
     "\n",
@@ -2644,7 +1731,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2665,42 +1752,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "2"
-      ]
-     },
-     "execution_count": 99,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "chained[\"b\"]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3"
-      ]
-     },
-     "execution_count": 100,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Assigned 3 not 4 because dict1 was paased first.\n",
     "\n",
@@ -2716,20 +1781,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Counter({1: 3, 2: 3, 3: 3, 5: 3, 7: 3, 4: 3, 9: 3})"
-      ]
-     },
-     "execution_count": 101,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"Counter([iterable-or-mapping])\n",
     "\n",
@@ -2755,7 +1809,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2770,40 +1824,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "OrderedDict([('a', 1), ('b', 2), ('c', 3), ('d', 4)])"
-      ]
-     },
-     "execution_count": 103,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ordered_dict"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "a 1\n",
-      "b 2\n",
-      "c 3\n",
-      "d 4\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Supports all dictionary functions.\n",
     "\n",
@@ -2820,18 +1852,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'m': 1, 'i': 4, 's': 4, 'p': 2}\n",
-      "[('m', 1), ('i', 4), ('s', 4), ('p', 2)]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"defaultdict([default_factory[, ...]])\n",
     "\n",
@@ -2865,20 +1888,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[('yellow', [1, 3]), ('blue', [2, 4]), ('red', [1])]"
-      ]
-     },
-     "execution_count": 106,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Setting the default to a list.\n",
     "\n",
@@ -2906,20 +1918,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Functools has a lot of wrapper tools and functionality. \\nI may go over them at some point. For now I think partial and reduce\\nare very good to know.\\n'"
-      ]
-     },
-     "execution_count": 107,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from functools import *\n",
     "\n",
@@ -2938,7 +1939,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2959,17 +1960,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 109,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Joe Smith 10\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "freshman(\"Joe\", \"Smith\")"
    ]
@@ -2983,18 +1976,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "False\n",
-      "True\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"partialmethod(func, *args, **keywords)\n",
     "\n",
@@ -3031,20 +2015,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3628800"
-      ]
-     },
-     "execution_count": 111,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"reduce(function, iterable, initializer=None)\n",
     "\n",
@@ -3063,20 +2036,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 112,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "10"
-      ]
-     },
-     "execution_count": 112,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Another great example is using reduce to compare elements in a list against each other.\n",
     "\n",
@@ -3085,22 +2047,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1"
-      ]
-     },
-     "execution_count": 113,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "reduce(lambda x, y: y if y < x else x, list_1) # Finding the smallest number in the list"
    ]
@@ -3114,20 +2065,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 114,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'lru_cache(maxsize=128, typed=False)\\n\\nDecorator to wrap a function with a memoizing callable that saves up to the maxsize most recent calls.\\n'"
-      ]
-     },
-     "execution_count": 114,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"lru_cache(maxsize=128, typed=False)\n",
     "\n",
@@ -3137,7 +2077,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 115,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3152,7 +2092,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 116,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3176,7 +2116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 117,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3206,7 +2146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3215,20 +2155,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 119,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "datetime.datetime(2020, 2, 4, 10, 43, 55, 762863)"
-      ]
-     },
-     "execution_count": 119,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"datetime()\n",
     "\n",
@@ -3242,19 +2171,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 120,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Today is the 4 day of month 2, and the year is 2020!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "now = datetime.now()\n",
     "\n",
@@ -3276,17 +2197,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 121,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The current month is February.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"strftime() \n",
     "\n",
@@ -3304,17 +2217,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 122,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Today's date is 04-02-2020. Be careful; It's not a datetimeobject anymore it is a <class 'str'>!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# strftime() can generally be used to format datetime objects.\n",
     "\n",
@@ -3332,20 +2237,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 123,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "I started studying in university back in 21-10-2015\n",
-      "and I'll finish in 17-10-2018\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"timedelta()\n",
     "Used to get a date X days\\months\\etc from now.\n",
@@ -3381,7 +2277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3390,7 +2286,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 125,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3401,7 +2297,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 126,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3412,36 +2308,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 127,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['LICENSE.md',\n",
-       " '.DS_Store',\n",
-       " 'random_tips.ipynb',\n",
-       " 'functions_and_classes.ipynb',\n",
-       " 'built_in_functions_and_libraries.ipynb',\n",
-       " '.gitignore',\n",
-       " '.ipynb_checkpoints',\n",
-       " 'general_tips.ipynb',\n",
-       " 'README.rst',\n",
-       " '.git']"
-      ]
-     },
-     "execution_count": 127,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "os.listdir() # Shows what files are in your directory. Equivalent to: ls -a"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 128,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3454,7 +2330,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 129,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3467,7 +2343,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 130,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3478,7 +2354,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 131,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3500,7 +2376,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 132,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3511,20 +2387,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 133,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'python_tips'"
-      ]
-     },
-     "execution_count": 133,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# This should remove everything except the name of the directory this file is located.\n",
     "\n",
@@ -3533,7 +2398,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 134,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3544,7 +2409,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 135,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3555,20 +2420,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 136,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 136,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Used to check if a path exists.\n",
     "\n",
@@ -3577,20 +2431,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 137,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 137,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Used to check if something is a dir.\n",
     "\n",
@@ -3599,20 +2442,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 138,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "False"
-      ]
-     },
-     "execution_count": 138,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Used to check if something is a file.\n",
     "\n",
@@ -3621,20 +2453,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 139,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "('file', '.txt')"
-      ]
-     },
-     "execution_count": 139,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# # Useful for handling extensions.\n",
     "\n",
@@ -3658,7 +2479,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/built_in_functions_and_libraries.ipynb
+++ b/built_in_functions_and_libraries.ipynb
@@ -238,7 +238,7 @@
     {
      "data": {
       "text/plain": [
-       "<zip at 0x7fe158601500>"
+       "<zip at 0x7ff03ccbd6c0>"
       ]
      },
      "execution_count": 9,
@@ -811,7 +811,7 @@
     {
      "data": {
       "text/plain": [
-       "'2022-08-22 21:15:33.936843'"
+       "'2022-08-23 00:53:52.890433'"
       ]
      },
      "execution_count": 33,
@@ -835,7 +835,7 @@
     {
      "data": {
       "text/plain": [
-       "'datetime.datetime(2022, 8, 22, 21, 15, 33, 975662)'"
+       "'datetime.datetime(2022, 8, 23, 0, 53, 52, 922075)'"
       ]
      },
      "execution_count": 34,
@@ -916,6 +916,9 @@
     "This creates an iterable object that goes up by the step you specify.\n",
     "This will continuously yield increments of 5 i.e. 0, 5, 10, 15, 20...\n",
     "\n",
+    "Remember: Each time your generator is called upon using next, it will only then yield the result. \n",
+    "This will continue until your generator is exhausted.\n",
+    "\n",
     "Do not use as a list.\n",
     "\"\"\"\n",
     "\n",
@@ -993,6 +996,7 @@
     "\"\"\"repeat(object, times=None)\n",
     "\n",
     "Used to repeat an element up to n times.\n",
+    "\n",
     "\n",
     "Works as a generator.\n",
     "\"\"\"\n",
@@ -1099,7 +1103,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['a', 'b', 'c', 'e', 'f', 'd', 'g', 'h', 'i', 'j', 'k', 'l']\n"
+      "['a', 'b', 'c', 'f', 'e', 'd', 'g', 'h', 'i', 'j', 'k', 'l']\n"
      ]
     }
    ],
@@ -1148,7 +1152,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['a', 'b', 'c', 'e', 'f', 'd', 'g', 'h', 'i', 'j', 'k', 'l']\n"
+      "['a', 'b', 'c', 'f', 'e', 'd', 'g', 'h', 'i', 'j', 'k', 'l']\n"
      ]
     }
    ],
@@ -1233,6 +1237,9 @@
    ],
    "source": [
     "# Generator\n",
+    "\n",
+    "#Remember: Each time your generator is called upon using next, it will only then yield the result. \n",
+    "#This will continue until your generator is exhausted.\n",
     "\n",
     "compress_obj = compress(\"ABCDEF\", [1, 0, 1, 0, 1, 1])\n",
     "\n",
@@ -1662,7 +1669,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(<itertools._tee object at 0x7fe158635380>, <itertools._tee object at 0x7fe158635440>, <itertools._tee object at 0x7fe158635480>)\n"
+      "(<itertools._tee object at 0x7ff03cce4b40>, <itertools._tee object at 0x7ff03cba0d40>, <itertools._tee object at 0x7ff03cba09c0>)\n"
      ]
     }
    ],
@@ -1759,6 +1766,9 @@
    ],
    "source": [
     "zip_longest_obj = zip_longest(\"ABCD\", \"xy\", fillvalue=\"-\")\n",
+    "\n",
+    "#Remember: Each time your generator is called upon using next, it will only then yield the result. \n",
+    "#This will continue until your generator is exhausted.\n",
     "\n",
     "print(next(zip_longest_obj))"
    ]
@@ -2824,7 +2834,7 @@
     "    else:\n",
     "        d[letter] += 1\n",
     "        \n",
-    "print(d)\n",
+    "print(d) \n",
     "        \n",
     "# Similar to\n",
     "\n",
@@ -3180,7 +3190,7 @@
     {
      "data": {
       "text/plain": [
-       "datetime.datetime(2022, 8, 22, 21, 15, 35, 126432)"
+       "datetime.datetime(2022, 8, 23, 0, 53, 54, 59962)"
       ]
      },
      "execution_count": 116,
@@ -3210,7 +3220,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Today is the 22 day of month 8, and the year is 2022!\n"
+      "Today is the 23 day of month 8, and the year is 2022!\n"
      ]
     }
    ],
@@ -3270,7 +3280,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Today's date is 22-08-2022. Be careful; It's not a datetimeobject anymore it is a <class 'str'>!\n"
+      "Today's date is 23-08-2022. Be careful; It's not a datetimeobject anymore it is a <class 'str'>!\n"
      ]
     }
    ],

--- a/functions_and_classes.ipynb
+++ b/functions_and_classes.ipynb
@@ -708,7 +708,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<function html_wrap.<locals>.msg_to_wrap at 0x7ff4125f15e0>\n"
+      "<function html_wrap.<locals>.msg_to_wrap at 0x7f971fde1b80>\n"
      ]
     }
    ],
@@ -881,7 +881,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[*] Execution time: 0.46527695655822754 seconds.\n"
+      "[*] Execution time: 0.39233899116516113 seconds.\n"
      ]
     }
    ],
@@ -1072,11 +1072,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<function num at 0x7ff4125bff70> func1\n",
+      "<function num at 0x7f9720103280> func1\n",
       "1\n",
-      "<function decorator.<locals>.inner1 at 0x7ff4125bf430> func2\n",
+      "<function decorator.<locals>.inner1 at 0x7f97201035e0> func2\n",
       "2\n",
-      "<function decorator1.<locals>.inner2 at 0x7ff4125bf160> func3\n",
+      "<function decorator1.<locals>.inner2 at 0x7f97201039d0> func3\n",
       "3\n",
       "4\n",
       "5\n",
@@ -1588,7 +1588,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<__main__.Dog object at 0x7ff4125e8820>\n"
+      "<__main__.Dog object at 0x7f972011f130>\n"
      ]
     }
    ],
@@ -1606,7 +1606,7 @@
     {
      "data": {
       "text/plain": [
-       "<__main__.Dog at 0x7ff4125e8820>"
+       "<__main__.Dog at 0x7f972011f130>"
       ]
      },
      "execution_count": 66,
@@ -1654,7 +1654,7 @@
     {
      "data": {
       "text/plain": [
-       "<__main__.Dog at 0x7ff4128ac7f0>"
+       "<__main__.Dog at 0x7f9720117850>"
       ]
      },
      "execution_count": 68,
@@ -1793,7 +1793,7 @@
    "source": [
     "<u>Static Methods</u>\n",
     "\n",
-    "The staticmethod decorator allows us to include methods within a class that do not pertain to the class object we are working with. It is essentially a normal function attached to our class.\n",
+    "The static method decorator allows us to include methods within a class that do not pertain to the class object we are working with. It is essentially a normal function attached to our class.\n",
     "\n",
     "We generally use static methods to create utility functions."
    ]

--- a/general_tips.ipynb
+++ b/general_tips.ipynb
@@ -700,7 +700,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/general_tips.ipynb
+++ b/general_tips.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# TABLE OF CONTENTS:<a id='toc'></a>\n",
     "\n",
-    "These tips are focused on general Python tips I think that are good to know.\n",
+    "These tips are focused on general Python tips I think are good to know.\n",
     "\n",
     "Please go through official documentation if you want more thorough examples.\n",
     "\n",

--- a/random_tips.ipynb
+++ b/random_tips.ipynb
@@ -195,7 +195,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updated all files to work in Python 3.8.X and expanded on the following sections:

- itertools tee
- combinations with replacements
- named tuple
- chain maps
- OrderedDict